### PR TITLE
enable cliff deconstruction planner when researching cliff explosives

### DIFF
--- a/prototypes/technologies/arrival-phase.lua
+++ b/prototypes/technologies/arrival-phase.lua
@@ -867,6 +867,10 @@ data:extend({
         type = "unlock-recipe",
         recipe = "cliff-explosives"
       },
+      {
+        type = "cliff-deconstruction-enabled",
+        modifier = true
+      },  
     },
     prerequisites = {"crystal-excitation"},
     unit = {


### PR DESCRIPTION
If you don't set this flag you aren't able to make deconstruction requests for bots to use cliff explosives and since you don't have a body are unable to use them.

This fix is probably correct because I did it before for a different mod but I didn't bother to test it.